### PR TITLE
Fix count overflow protection

### DIFF
--- a/symspell/SymSpell.cs
+++ b/symspell/SymSpell.cs
@@ -122,7 +122,7 @@ public static class SymSpell
 
             countPrevious = value.count;
             //summarizes multiple frequency entries of a word (prevents overflow)
-            value.count = Math.Min(Int64.MaxValue, value.count + count);
+            value.count = (Int64.MaxValue - value.count > count) ? value.count + count : Int64.MaxValue;
         }
         else 
         {
@@ -200,7 +200,7 @@ public static class SymSpell
                     //Int64 count;
                     if (Int64.TryParse(lineParts[countIndex], out Int64 count))
                     {
-                        CreateDictionaryEntry(key, language, Math.Min(Int64.MaxValue, count));
+                        CreateDictionaryEntry(key, language, count);
                     }
                 }
             }

--- a/symspell/symspell.csproj
+++ b/symspell/symspell.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <Optimize>True</Optimize>
+    <Optimize>false</Optimize>
     <DefineConstants>NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
 

--- a/symspelldemo/symspelldemo.csproj
+++ b/symspelldemo/symspelldemo.csproj
@@ -16,7 +16,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>
     </DefineConstants>


### PR DESCRIPTION
The first `Math.Min(Int64.MaxValue` change is needed because the overflow will happen before the Math.Min function is called. The second `Math.Min(Int64.MaxValue` call was removed because it's unneccessary (count is an Int64, so it can never be larger than `Int64.MaxValue`).
Turned optimizations off for debug build to allow easier debugging.