### PR TITLE
Combine dictionary and itemList

### DIFF
--- a/symspell.Benchmark/SymSpell.Benchmark.cs
+++ b/symspell.Benchmark/SymSpell.Benchmark.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace symspell.Benchmark
 {
@@ -60,9 +61,13 @@ namespace symspell.Benchmark
         // pre-run to ensure code has executed once before timing benchmarks
         static void WarmUp()
         {
-            SymSpell dict = new SymSpell(2, 7);
+            SymSpell dict = new SymSpell(16, 2, 7);
             dict.LoadDictionary(DictionaryPath[0], 0, 1);
-            var result = dict.Lookup("hockie", SymSpell.Verbosity.All);
+            var result = dict.Lookup("hockie", SymSpell.Verbosity.All, 1);
+
+            Original.SymSpell dictOrig = new Original.SymSpell(2, 7);
+            dictOrig.LoadDictionary(DictionaryPath[0], "", 0, 1);
+            var resultOrig = dictOrig.Lookup("hockie", "", 1, 2);
         }
 
         static void BenchmarkPrecalculationLookup()
@@ -80,15 +85,15 @@ namespace symspell.Benchmark
                     //benchmark dictionary precalculation size and time 
                     //maxEditDistance=1/2/3; prefixLength=5/6/7;  dictionary=30k/82k/500k; class=instantiated/static
                     for (int i=0;i< DictionaryPath.Length;i++)
-                    {                                             
-                        //instantiated dictionary                      
+                    {
+                        //instantiated dictionary        
                         long memSize = GC.GetTotalMemory(true);
                         stopWatch.Restart();
-                        SymSpell dict = new SymSpell(maxEditDistance, prefixLength);
+                        SymSpell dict = new SymSpell(30000, maxEditDistance, prefixLength);
                         dict.LoadDictionary(DictionaryPath[i], 0, 1);
                         stopWatch.Stop();
                         long memDelta = GC.GetTotalMemory(true) - memSize;
-                        Console.WriteLine("Precalculation instance "+stopWatch.Elapsed.TotalSeconds.ToString("N3")+"s "+(memDelta/1024/1024).ToString("N0")+ "MB " + dict.WordCount.ToString("N0") + " words " + dict.EntryCount.ToString("N0") + " entries  MaxEditDistance=" + maxEditDistance.ToString() + " prefixLength=" + prefixLength.ToString() + " dict=" + DictionaryName[i]);
+                        Console.WriteLine("Precalculation instance "+stopWatch.Elapsed.TotalSeconds.ToString("N3")+"s "+(memDelta/1024/1024.0).ToString("N1")+ "MB " + dict.WordCount.ToString("N0") + " words " + dict.EntryCount.ToString("N0") + " entries  MaxEditDistance=" + maxEditDistance.ToString() + " prefixLength=" + prefixLength.ToString() + " dict=" + DictionaryName[i]);
 
                         //static dictionary 
                         memSize = GC.GetTotalMemory(true);
@@ -97,7 +102,7 @@ namespace symspell.Benchmark
                         dictOrig.LoadDictionary(DictionaryPath[i], "", 0, 1);
                         stopWatch.Stop();
                         memDelta = GC.GetTotalMemory(true) - memSize;
-                        Console.WriteLine("Precalculation static   " + stopWatch.Elapsed.TotalSeconds.ToString("N3") + "s " + (memDelta / 1024 / 1024).ToString("N0") + "MB " + dict.WordCount.ToString("N0") + " words " + dict.EntryCount.ToString("N0") + " entries  MaxEditDistance=" + maxEditDistance.ToString() + " prefixLength=" + prefixLength.ToString() + " dict=" + DictionaryName[i]);
+                        Console.WriteLine("Precalculation static   " + stopWatch.Elapsed.TotalSeconds.ToString("N3") + "s " + (memDelta / 1024 / 1024.0).ToString("N1") + "MB " + dict.WordCount.ToString("N0") + " words " + dict.EntryCount.ToString("N0") + " entries  MaxEditDistance=" + maxEditDistance.ToString() + " prefixLength=" + prefixLength.ToString() + " dict=" + DictionaryName[i]);
 
                         //benchmark lookup result number and time
                         //maxEditDistance=1/2/3; prefixLength=5/6/7; dictionary=30k/82k/500k; verbosity=0/1/2; query=exact/non-exact/mix; class=instantiated/static

--- a/symspell.Test/SymSpell.Test.cs
+++ b/symspell.Test/SymSpell.Test.cs
@@ -9,6 +9,32 @@ namespace symspell.Test
     public class SymSpellTests
     {
         [Test]
+        public void WordsWithSharedPrefixShouldRetainCounts()
+        {
+            var symSpell = new SymSpell(16, 1, 3);
+            symSpell.CreateDictionaryEntry("pipe", 5);
+            symSpell.CreateDictionaryEntry("pips", 10);
+            var result = symSpell.Lookup("pipe", SymSpell.Verbosity.All, 1);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("pipe", result[0].term);
+            Assert.AreEqual(5, result[0].count);
+            Assert.AreEqual("pips", result[1].term);
+            Assert.AreEqual(10, result[1].count);
+            result = symSpell.Lookup("pips", SymSpell.Verbosity.All, 1);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("pips", result[0].term);
+            Assert.AreEqual(10, result[0].count);
+            Assert.AreEqual("pipe", result[1].term);
+            Assert.AreEqual(5, result[1].count);
+            result = symSpell.Lookup("pip", SymSpell.Verbosity.All, 1);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("pips", result[0].term);
+            Assert.AreEqual(10, result[0].count);
+            Assert.AreEqual("pipe", result[1].term);
+            Assert.AreEqual(5, result[1].count);
+        }
+
+        [Test]
         public void AddAdditionalCountsShouldNotAddWordAgain()
         {
             var symSpell = new SymSpell();
@@ -88,6 +114,24 @@ namespace symspell.Test
             Assert.AreEqual("steama", result[0].term);
         }
         [Test]
+        public void LookupShouldNotReturnNonWordDelete()
+        {
+            var symSpell = new SymSpell(16, 2, 7, 10);
+            symSpell.CreateDictionaryEntry("pawn", 10);
+            var result = symSpell.Lookup("paw", SymSpell.Verbosity.Top, 0);
+            Assert.AreEqual(0, result.Count);
+            result = symSpell.Lookup("awn", SymSpell.Verbosity.Top, 0);
+            Assert.AreEqual(0, result.Count);
+        }
+        [Test]
+        public void LookupShouldNotReturnLowCountWord()
+        {
+            var symSpell = new SymSpell(16, 2, 7, 10);
+            symSpell.CreateDictionaryEntry("pawn", 1);
+            var result = symSpell.Lookup("pawn", SymSpell.Verbosity.Top, 0);
+            Assert.AreEqual(0, result.Count);
+        }
+        [Test]
         public void ShouldReplicateNoisyResults()
         {
             var dir = AppDomain.CurrentDomain.BaseDirectory;
@@ -95,7 +139,7 @@ namespace symspell.Test
             const int editDistanceMax = 2;
             const int prefixLength = 7;
             const SymSpell.Verbosity verbosity = SymSpell.Verbosity.Closest;
-            var symSpell = new SymSpell(editDistanceMax, prefixLength);
+            var symSpell = new SymSpell(83000, editDistanceMax, prefixLength);
             string path = dir + "../../../SymSpell/frequency_dictionary_en_82_765.txt";    //for spelling correction (genuine English words)
 
             symSpell.LoadDictionary(path, 0, 1);


### PR DESCRIPTION
Added initialCapacity constructor parameter (note, this is a breaking change, as this was made as the first parameter, and is of the same type as the first parameter in the previous version - construction of a new SymSpell should typically always include an initial capacity since dictionaries are typically large, of a known size, and specifying an appropriate initial capacity speeds up loading a dictionary as it avoids needless collection grow cycles)
Added countThreshold constructor parameter
Combined dictionary and itemList into a single Dictionary
Fixed bug in Lookup that returned exact matches to under-threshold words in some circumstances
Added more unit tests
Increased benchmark memory display precision
Added benchmark warmup for original SymSpell.