### PR TITLE
Update Rust port link

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ https://www.kaggle.com/yk1598/symspell-spell-corrector
 https://github.com/PhilT/symspell
 
 **Rust**<br>
-https://docs.rs/crate/symspell/
+https://github.com/reneklacan/symspell
 
 **Scala**<br>
 https://github.com/semkath/symspell


### PR DESCRIPTION
Hey @wolfgarbe,

first of all thank you very much for open-sourcing such a great library like SymSpell.

I noticed you already included link to Rust port docs few days ago while the repo was still private (I am surprised you even found it!) so I'm just updating a link to point to now public repository.