### PR TITLE
Fix for null reference exception

### DIFF
--- a/SymSpell/SymSpell.cs
+++ b/SymSpell/SymSpell.cs
@@ -224,7 +224,9 @@ public class SymSpell
         //even if the same term existed before in the dictionary as an edit from another word
         if (key.Length > maxDictionaryWordLength) maxDictionaryWordLength = key.Length;
 
-        //create deletes
+	if (deletes == null) this.deletes = new Dictionary<int, string[]>(initialCapacity); //initialisierung
+
+	//create deletes
         var edits = EditsPrefix(key);
         // if not staging suggestions, put directly into main data structure
         if (staging != null)
@@ -233,7 +235,6 @@ public class SymSpell
         }
         else
         {
-            if (deletes == null) this.deletes = new Dictionary<int, string[]>(initialCapacity); //initialisierung
             foreach (string delete in edits)
             {
                 int deleteHash = GetStringHash(delete);


### PR DESCRIPTION
If you use only CreateDictionaryEntry() with a staging object the line that initialized deletes doesn't get called, which means when you call CommitStaged() you get a null reference exception. Moved the initialization line so it will be initialized on both branches.